### PR TITLE
Add user auth error messages to display in login and register page

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -9,6 +9,7 @@
 :root {
   --primary-color: #17a2b8;
   --dark-color: #343a40;
+  --danger-color: #ff4444;
 }
 
 * {
@@ -207,6 +208,19 @@ button:focus {
 .password-input-register {
   width: 400px;
   text-align: center;
+}
+
+#alert-msg {
+  position: absolute;
+  padding: 0.7rem 2rem;
+  z-index: 6001;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #ff4444;
+  text-align: center;
+  line-height: 2.5;
+  overflow: hidden;
 }
 
 /* different viewport support */

--- a/client/src/actions/alert_action.js
+++ b/client/src/actions/alert_action.js
@@ -1,0 +1,13 @@
+import { SET_ALERT, REMOVE_ALERT } from './types';
+import uuid from 'uuid';
+
+export const setAlert = (msg, type) => dispatch => {
+  const id = uuid.v4();
+
+  dispatch ({
+    type: SET_ALERT,
+    data: { msg, type, id }
+  });
+
+  setTimeout(() => dispatch({ type: REMOVE_ALERT, data: id }), 3000);
+};

--- a/client/src/actions/auth.js
+++ b/client/src/actions/auth.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { setAlert } from './alert_action';
 import {
   REGISTER_SUCCESS,
   REGISTER_FAIL,
@@ -48,6 +49,12 @@ export const register = ({ name, email, password }) => async dispatch => {
 
     dispatch(loadUser());
   } catch (err) {
+    const errors = err.response.data.errors;
+
+    if (errors) {
+      errors.forEach(error => dispatch(setAlert(error.msg, '')));
+    }
+    
     dispatch ({
       type: REGISTER_FAIL
     });
@@ -72,6 +79,12 @@ export const login = (email, password) => async dispatch => {
 
     dispatch(loadUser());
   } catch (err) {
+    const errors = err.response.data.errors;
+
+    if (errors) {
+      errors.forEach(error => dispatch(setAlert(error.msg, '')));
+    }
+
     dispatch({
       type: LOGIN_FAIL
     });

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -1,3 +1,5 @@
+export const SET_ALERT = 'SET_ALERT';
+export const REMOVE_ALERT = 'REMOVE_ALERT';
 export const REGISTER_SUCCESS = 'REGISTER_SUCCESS';
 export const REGISTER_FAIL = 'REGISTER_FAIL';
 export const USER_LOADED = 'USER_LOADED';

--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -3,6 +3,7 @@ import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { login } from '../../actions/auth';
+import Alert from '../layout/alert';
 
 const Login = ({ login, isAuthenticated }) => {
   const [formData, setFormData] = useState({
@@ -32,6 +33,7 @@ const Login = ({ login, isAuthenticated }) => {
       <div className="dark-overlay">
         <div className="landing-inner">
           <h1>Please sign in</h1>
+          <Alert />
           <form className='form form-login' onSubmit={e => onSubmit(e)}>
             <div className='form-group'>
               <input

--- a/client/src/components/auth/Register.js
+++ b/client/src/components/auth/Register.js
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { Link, Redirect } from 'react-router-dom';
 import { register } from '../../actions/auth';
+import { setAlert } from '../../actions/alert_action';
+import Alert from '../layout/alert';
 import PropTypes from 'prop-types';
 
-const Register = ({ register, isAuthenticated }) => {
+const Register = ({ setAlert, register, isAuthenticated }) => {
   const [formData, setFormData] = useState ({
     name: '',
     email: '',
@@ -23,7 +25,7 @@ const Register = ({ register, isAuthenticated }) => {
     e.preventDefault();
 
     if (password !== password2) {
-      console.log("Invalid, passwords don't match!");
+      setAlert("Invalid, passwords don't match!", 'danger');
     } else {
       register({ name, email, password });
     }
@@ -38,6 +40,7 @@ const Register = ({ register, isAuthenticated }) => {
       <div className="dark-overlay">
         <div className="landing-inner">
           <h1> Please sign Up</h1>
+          <Alert />
           <form className='form form-register' onSubmit={e => onSubmit(e)}>
             <div className='form-group'>
               <input
@@ -89,6 +92,7 @@ const Register = ({ register, isAuthenticated }) => {
 };
 
 Register.propTypes = {
+  setAlert: PropTypes.func.isRequired,
   register: PropTypes.func.isRequired
 };
 
@@ -98,5 +102,5 @@ const mapStateToProps = state => ({
 
 export default connect(
   mapStateToProps,
-  { register }
+  { setAlert, register }
 )(Register);

--- a/client/src/components/layout/alert.js
+++ b/client/src/components/layout/alert.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+const alert = ({ alerts }) => 
+alerts !== null &&
+alerts.length > 0 &&
+alerts.map(alert => (
+  <div key={alert.id} id="alert-msg" className={`alert alert-${alert.type}`}>
+    {alert.msg}
+  </div>
+));
+
+alert.propTypes = {
+  alerts: PropTypes.array.isRequired,
+};
+
+const mapStateToProps = state => ({
+  alerts: state.alert
+});
+
+export default connect(mapStateToProps)(alert)

--- a/client/src/components/layout/navbar.js
+++ b/client/src/components/layout/navbar.js
@@ -8,7 +8,7 @@ const Navbar = ({ auth: { isAuthenticated, loading }, logout }) => {
   const aLinks = (
     <ul>
       <li className="nav-signup">
-        <a onClick={logout} href="#!">Logout</a>
+        <a onClick={logout} href="#">Logout</a>
       </li>
       <li className="dropdown-menu">
         <Link to="/"><i className="fas fa-bars"></i></Link>

--- a/client/src/reducers/alert_reducer.js
+++ b/client/src/reducers/alert_reducer.js
@@ -1,0 +1,14 @@
+import { SET_ALERT, REMOVE_ALERT } from '../actions/types';
+
+const initialState = {};
+
+export default function (state = initialState, action) {
+  switch(action.type) {
+    case SET_ALERT:
+      return [action.data];
+    case REMOVE_ALERT:
+      return state.filter(alert => alert.id !== action.data);
+    default:
+      return state;
+  }
+}

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import auth from './auth';
+import alert from './alert_reducer';
 
 export default combineReducers ({
-  auth
+  auth,
+  alert
 });


### PR DESCRIPTION
The user auth errors are now being displayed properly on the login and register page. Also 
the error message should show up and then disappear after 3 seconds.

Fixes #21