### PR TITLE
Bar chart failure fix

### DIFF
--- a/client/src/components/article/article_show.jsx
+++ b/client/src/components/article/article_show.jsx
@@ -55,13 +55,7 @@ export class ArticleShow extends React.Component {
                         allTextCitationCount += 1
                     }
                 })
-                
-                // format data as needed
 
-                // if it's gov or edu, then pair
-                // if it's org then have it on its own
-                // if net or com or anything else then pair
-                // Go through and format as needed
                 const domainCounts = { 
                     'books_text': 0,
                     'edu_gov': 0,
@@ -104,7 +98,6 @@ export class ArticleShow extends React.Component {
     render() {
         return (
             <div className="article-show-page-container">
-                {/* <WikiSearchContainer /> */}
                 <div className="article-header-container">
                     <div className="article-title">                    
                         {this.state.articleTitle}

--- a/client/src/components/article/charts/bar_chart.jsx
+++ b/client/src/components/article/charts/bar_chart.jsx
@@ -64,7 +64,6 @@ export class BarChart extends Component {
         const margin = 60;
         const chartWidth = 1000 - 2 * margin
         const chartHeight = 600 - 2 * margin
-        console.log('Chart Height' + chartHeight)
 
         const svg = d3.select('#bar_chart_svg')
                       .attr('width', chartWidth + 100)
@@ -117,6 +116,11 @@ export class BarChart extends Component {
             .enter()
             .append('text')
             .text(function (d) {
+                if (d.value === undefined) {
+                    // if d.value is undefined, this most likely means that user is blacklisted
+                        //  thus we will give them lifetime contribution of 1
+                    d.value = 1;
+                }
                 // Number format source : https://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
                 return d.value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
             })


### PR DESCRIPTION
### Bug:
The cause of #46 appears to be that some usernames have an `undefined` number of lifetime edits.

### Reason for bug:
I investigated this, and it looks like all these users, which tend to have 4 sets of numbers and 3 dots in their username, are considered to be blacklisted. 

I came to this conclusion because I tried signing up to Wikipedia using the same username format, and I got this message everytime:
![image](https://user-images.githubusercontent.com/27740273/66793965-8dad9c80-eeb4-11e9-86f0-10a9a8670e93.png)

Plus, names without letters are not allowed:
![image](https://user-images.githubusercontent.com/27740273/66793991-a0c06c80-eeb4-11e9-856a-d15d3388d10d.png)

Lastly, when I modify the naming convention slightly (adding one extra number at the end), I get this:
![image](https://user-images.githubusercontent.com/27740273/66794031-c9486680-eeb4-11e9-9d98-eedfa16e2380.png)

All this information, plus the fact that all these users' edits tend to be old have made me assume that they are blacklisted.

### Fix:
I placed 1 lifetime contribution for each of these seemingly blacklisted users. This should be true in all cases since we know for a fact that they had edited the article that is currently showing. 

### How to check that it's working:
Going to "OK!" article should not crash the website now. All other article show pages and other site functionalities should work the same as before.

Fixes #46 